### PR TITLE
Address plotter failure, bump ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.22"
+    rev: "v0.16.4"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/htdocs/images/plotter.php
+++ b/htdocs/images/plotter.php
@@ -856,7 +856,7 @@ if ($obs == "1" && in_array($site, $sites)) {
             $obs_time[] = $ob_time;
             $obs_temp[] = $d[2];
             $obs_dew[] = $d[3];
-            if ($d[4] != "") {
+            if (is_numeric($d[4])) {
                 $obs_wspd[] = $d[4] * 1.15077945;
             } else {
                 $obs_wspd[] = "";

--- a/htdocs/images/plotter.php
+++ b/htdocs/images/plotter.php
@@ -856,7 +856,11 @@ if ($obs == "1" && in_array($site, $sites)) {
             $obs_time[] = $ob_time;
             $obs_temp[] = $d[2];
             $obs_dew[] = $d[3];
-            $obs_wspd[] = $d[4] * 1.15077945;
+            if ($d[4] != "") {
+                $obs_wspd[] = $d[4] * 1.15077945;
+            } else {
+                $obs_wspd[] = "";
+            }
             $obs_wdir[] = $d[5];
             $obs_precip[] = $d[6];
             $obs_precip_accum[] = array_sum($obs_precip);
@@ -1170,7 +1174,6 @@ $nws_time_temp = array();
 $nws_var_temp = array();
 for ($i = 0; $i < $len; $i++) {
     if ($nws_time[$i] >= $start && $nws_time[$i] <= $end) {
-        //echo date("Y-m-d H:i:s",$nws_time[$i]).",".date("Y-m-d H:i:s",$start).",".date("Y-m-d H:i:s",$end)."<br>";
         $nws_time_temp[] = $nws_time[$i];
         $nws_var_temp[] = $nws_var[$i];
     }
@@ -2166,6 +2169,14 @@ if ($obs == 1 && !empty($obs_var1) && !empty($obs_time) && count($obs_var1) == c
         $graph->Add($lineplot_obs1);
     }
     $lineplot_obs1->mark->SetFillColor("cyan1");
+}
+
+// Check to see if anything has been plotted to the graph
+if (sizeof($graph->plots) === 0){
+    $bad = imagecreatefrompng("not_available.png");
+    header('Content-Type: image/png');
+    imagepng($bad);
+    die();
 }
 
 if ($var == "wdir") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Missing wind-speed observations are now displayed as unavailable rather than incorrectly converted to numeric values.
  - Graph requests with no available plot data now show a clear “not available” image instead of producing an empty or misleading graph.

- **Maintenance**
  - Updated code-quality checks to improve consistency and reliability across future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->